### PR TITLE
Constructor束縛に変更

### DIFF
--- a/src/Annotation/Cookie.php
+++ b/src/Annotation/Cookie.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\AuraSessionModule\Annotation;
+
+use Attribute;
+use Ray\Di\Di\Qualifier;
+
+/**
+ * @Annotation
+ * @Qualifier
+ */
+#[Attribute, Qualifier]
+final class Cookie
+{
+}

--- a/src/Annotation/DeleteCookie.php
+++ b/src/Annotation/DeleteCookie.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\AuraSessionModule\Annotation;
+
+use Attribute;
+use Ray\Di\Di\Qualifier;
+
+/**
+ * @Annotation
+ * @Qualifier
+ */
+#[Attribute, Qualifier]
+final class DeleteCookie
+{
+}

--- a/src/AuraSessionInject.php
+++ b/src/AuraSessionInject.php
@@ -1,23 +1,20 @@
 <?php
-/**
- * This file is part of the Ray.AuraSessionModule package.
- *
- * @license http://opensource.org/licenses/MIT MIT
- */
+
+declare(strict_types=1);
+
 namespace Ray\AuraSessionModule;
 
 use Aura\Session\Session;
 
+/**
+ * @deprecated Use PHP 8.0: Class constructor property promotion instead
+ */
 trait AuraSessionInject
 {
-    /**
-     * @var Session
-     */
+    /** @var Session */
     protected $session;
 
     /**
-     * @param Session $session
-     *
      * @\Ray\Di\Di\Inject
      */
     public function setSession(Session $session)

--- a/src/AuraSessionModule.php
+++ b/src/AuraSessionModule.php
@@ -1,12 +1,21 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * This file is part of the Ray.AuraSessionModule package.
- *
- * @license http://opensource.org/licenses/MIT MIT
  */
+
 namespace Ray\AuraSessionModule;
 
+use Aura\Session\CsrfTokenFactory;
+use Aura\Session\Phpfunc;
+use Aura\Session\Randval;
+use Aura\Session\RandvalInterface;
+use Aura\Session\SegmentFactory;
 use Aura\Session\Session;
+use Ray\AuraSessionModule\Annotation\Cookie;
+use Ray\AuraSessionModule\Annotation\DeleteCookie;
 use Ray\Di\AbstractModule;
 use Ray\Di\Scope;
 
@@ -17,6 +26,15 @@ class AuraSessionModule extends AbstractModule
      */
     protected function configure()
     {
-        $this->bind(Session::class)->toProvider(SessionProvider::class)->in(Scope::SINGLETON);
+        $this->bind(Session::class)->toConstructor(Session::class, [
+            'cookies' => Cookie::class,
+            'delete_cookie' => DeleteCookie::class
+        ]);
+        $this->bind()->annotatedWith(Cookie::class)->toProvider(CookieProvider::class);
+        $this->bind()->annotatedWith(DeleteCookie::class)->toInstance(null);
+        $this->bind(SegmentFactory::class);
+        $this->bind(CsrfTokenFactory::class);
+        $this->bind(RandvalInterface::class)->to(Randval::class);
+        $this->bind(Phpfunc::class)->in(Scope::SINGLETON);
     }
 }

--- a/src/CookieProvider.php
+++ b/src/CookieProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of the Ray.AuraSessionModule package.
+ */
+
+namespace Ray\AuraSessionModule;
+
+use Ray\Di\ProviderInterface;
+
+class CookieProvider implements ProviderInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @SuppressWarnings(PHPMD.Superglobals)
+     */
+    public function get()
+    {
+        return $_COOKIE;
+    }
+}

--- a/src/SessionProvider.php
+++ b/src/SessionProvider.php
@@ -9,6 +9,9 @@ namespace Ray\AuraSessionModule;
 use Aura\Session\SessionFactory;
 use Ray\Di\ProviderInterface;
 
+/**
+ * @deprecated
+ */
 class SessionProvider implements ProviderInterface
 {
     /**

--- a/tests/AuraSessionModuleTest.php
+++ b/tests/AuraSessionModuleTest.php
@@ -1,9 +1,11 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * This file is part of the Ray.AuraSessionModule package.
- *
- * @license http://opensource.org/licenses/MIT MIT
  */
+
 namespace Ray\AuraSessionModule;
 
 use Aura\Session\Session;
@@ -14,7 +16,7 @@ class AuraSessionModuleTest extends TestCase
 {
     public function testAuraSessionModule()
     {
-        $injector = new Injector(new AuraSessionModule);
+        $injector = new Injector(new AuraSessionModule());
         $session = $injector->getInstance(Session::class);
         $this->assertInstanceOf(Session::class, $session);
     }


### PR DESCRIPTION
Constructor束縛に変更することで

* `Session`がAOP適用可能になります。(Provider束縛で生成すると`new`をユーザーコードが行なってしまうのでAOPできません)
* クラス単位で束縛が変更できます。