### PR TITLE
Enable PHP 8.4 compat

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Exclude build/test files from archive.
+/tests                           export-ignore
+/.gitattributes                  export-ignore
+/.gitignore                      export-ignore
+/.scrutinizer.yml                export-ignore
+/php-require-checker.config.json export-ignore
+/php.ini                         export-ignore
+/codecov.yml                     export-ignore
+/phpcs.xml                       export-ignore
+/phpmd.xml                       export-ignore
+/phpstan.neon                    export-ignore
+/psalm.xml                       export-ignore
+/phpunit.xml.dist                export-ignore
+
+# Configure diff output for .php and .phar files.
+*.php diff=php
+*.phar -diff

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+# Alerts only major updates for Packagist (Composer)
+#
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "composer" # Specify the correct package ecosystem for PHP
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "*" # Ignore all dependencies for specific update types
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1"]'
-      current_stable: 8.2
+      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1", , "8.2", , "8.3"]'
+      current_stable: 8.4

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: ray-di/.github/.github/workflows/continuous-integration.yml@v1
     with:
-      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1", , "8.2", , "8.3"]'
+      old_stable: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3"]'
       current_stable: 8.4

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "ircmaxell/random-lib": "^1.1"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.5.29"
+        "phpunit/phpunit": "^8.5.29 || ^9"
     },
     "license": "MIT",
     "autoload":{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced configuration for Dependabot to manage PHP package updates, focusing on major updates only.
	- Updated `.gitattributes` to improve file export management and clarity of diffs for PHP files.
- **Improvements**
	- Updated Continuous Integration parameters to include additional PHP versions for better stability tracking.
	- Enhanced compatibility of the testing framework by allowing PHPUnit version 9 alongside the existing version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->