### PR TITLE
Add Psalm taint annotations for session/cookie security

### DIFF
--- a/src/Annotation/Cookie.php
+++ b/src/Annotation/Cookie.php
@@ -7,7 +7,8 @@ namespace Ray\AuraSessionModule\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute, Qualifier]
+#[Attribute]
+#[Qualifier]
 final class Cookie
 {
 }

--- a/src/Annotation/DeleteCookie.php
+++ b/src/Annotation/DeleteCookie.php
@@ -7,7 +7,8 @@ namespace Ray\AuraSessionModule\Annotation;
 use Attribute;
 use Ray\Di\Di\Qualifier;
 
-#[Attribute, Qualifier]
+#[Attribute]
+#[Qualifier]
 final class DeleteCookie
 {
 }

--- a/src/AuraSessionInject.php
+++ b/src/AuraSessionInject.php
@@ -6,15 +6,13 @@ namespace Ray\AuraSessionModule;
 
 use Aura\Session\Session;
 
-/**
- * @deprecated Use PHP 8.0: Class constructor property promotion instead
- */
+/** @deprecated Use PHP 8.0: Class constructor property promotion instead */
 trait AuraSessionInject
 {
     /** @var Session */
     protected $session;
 
-    public function setSession(Session $session)
+    public function setSession(Session $session): void
     {
         $this->session = $session;
     }

--- a/src/AuraSessionModule.php
+++ b/src/AuraSessionModule.php
@@ -22,7 +22,7 @@ use Ray\Di\Scope;
 class AuraSessionModule extends AbstractModule
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      */
     protected function configure()
     {

--- a/src/CookieProvider.php
+++ b/src/CookieProvider.php
@@ -13,9 +13,10 @@ use Ray\Di\ProviderInterface;
 class CookieProvider implements ProviderInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @SuppressWarnings(PHPMD.Superglobals)
+     * @psalm-taint-source input
      */
     public function get()
     {

--- a/src/DeleteCookieInvoker.php
+++ b/src/DeleteCookieInvoker.php
@@ -25,7 +25,7 @@ final class DeleteCookieInvoker
             '',
             time() - 42000,
             $params['path'],
-            $params['domain']
+            $params['domain'],
         );
     }
 }

--- a/src/DeleteCookieInvoker.php
+++ b/src/DeleteCookieInvoker.php
@@ -10,6 +10,8 @@ namespace Ray\AuraSessionModule;
 
 final class DeleteCookieInvoker
 {
+    public const EXPIRE_OFFSET = 42000;
+
     /**
      * Delete a cookie by setting its expiration time to a past value
      *
@@ -20,7 +22,7 @@ final class DeleteCookieInvoker
         setcookie(
             $name,
             '',
-            time() - 42000,
+            time() - self::EXPIRE_OFFSET,
             $params['path'],
             $params['domain'],
         );

--- a/src/DeleteCookieInvoker.php
+++ b/src/DeleteCookieInvoker.php
@@ -8,9 +8,6 @@ declare(strict_types=1);
 
 namespace Ray\AuraSessionModule;
 
-use function setcookie;
-use function time;
-
 final class DeleteCookieInvoker
 {
     /**

--- a/src/SessionProvider.php
+++ b/src/SessionProvider.php
@@ -1,26 +1,27 @@
 <?php
+
+declare(strict_types=1);
+
 /**
  * This file is part of the Ray.AuraSessionModule package.
- *
- * @license http://opensource.org/licenses/MIT MIT
  */
+
 namespace Ray\AuraSessionModule;
 
 use Aura\Session\SessionFactory;
 use Ray\Di\ProviderInterface;
 
-/**
- * @deprecated
- */
+/** @deprecated */
 class SessionProvider implements ProviderInterface
 {
     /**
-     * {@inheritdoc}
+     * {@inheritDoc}
      *
      * @SuppressWarnings(PHPMD.Superglobals)
+     * @psalm-taint-source input
      */
     public function get()
     {
-        return (new SessionFactory)->newInstance($_COOKIE);
+        return (new SessionFactory())->newInstance($_COOKIE);
     }
 }

--- a/tests/AuraSessionInjectTest.php
+++ b/tests/AuraSessionInjectTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\AuraSessionModule;
+
+use Aura\Session\Session;
+use PHPUnit\Framework\TestCase;
+
+class FakeSessionConsumer
+{
+    use AuraSessionInject;
+
+    public function getSession(): Session
+    {
+        return $this->session;
+    }
+}
+
+class AuraSessionInjectTest extends TestCase
+{
+    public function testSetSession(): void
+    {
+        $session = $this->createMock(Session::class);
+        $consumer = new FakeSessionConsumer();
+        $consumer->setSession($session);
+
+        $this->assertSame($session, $consumer->getSession());
+    }
+}

--- a/tests/DeleteCookieInvokerTest.php
+++ b/tests/DeleteCookieInvokerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\AuraSessionModule;
+
+use PHPUnit\Framework\TestCase;
+
+/** @var array<int, array{name: string, value: string, expires: int, path: string, domain: string}> */
+$setCookieCalls = [];
+
+/**
+ * Override time function for testing
+ */
+function time(): int
+{
+    return 1000000;
+}
+
+/**
+ * Override setcookie function for testing
+ *
+ * @return bool
+ */
+function setcookie(string $name, string $value = '', int $expires = 0, string $path = '', string $domain = '')
+{
+    global $setCookieCalls;
+
+    $setCookieCalls[] = [
+        'name' => $name,
+        'value' => $value,
+        'expires' => $expires,
+        'path' => $path,
+        'domain' => $domain,
+    ];
+
+    return true;
+}
+
+class DeleteCookieInvokerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        global $setCookieCalls;
+
+        $setCookieCalls = [];
+    }
+
+    public function testInvoke(): void
+    {
+        global $setCookieCalls;
+
+        $invoker = new DeleteCookieInvoker();
+        $invoker('test_cookie', ['path' => '/app', 'domain' => 'example.com']);
+
+        $this->assertCount(1, $setCookieCalls);
+        $this->assertSame('test_cookie', $setCookieCalls[0]['name']);
+        $this->assertSame('', $setCookieCalls[0]['value']);
+        $this->assertSame(1000000 - 42000, $setCookieCalls[0]['expires']);
+        $this->assertSame('/app', $setCookieCalls[0]['path']);
+        $this->assertSame('example.com', $setCookieCalls[0]['domain']);
+    }
+}

--- a/tests/DeleteCookieInvokerTest.php
+++ b/tests/DeleteCookieInvokerTest.php
@@ -56,7 +56,7 @@ class DeleteCookieInvokerTest extends TestCase
         $this->assertCount(1, $setCookieCalls);
         $this->assertSame('test_cookie', $setCookieCalls[0]['name']);
         $this->assertSame('', $setCookieCalls[0]['value']);
-        $this->assertSame(1000000 - 42000, $setCookieCalls[0]['expires']);
+        $this->assertSame(1000000 - DeleteCookieInvoker::EXPIRE_OFFSET, $setCookieCalls[0]['expires']);
         $this->assertSame('/app', $setCookieCalls[0]['path']);
         $this->assertSame('example.com', $setCookieCalls[0]['domain']);
     }

--- a/tests/SessionProviderTest.php
+++ b/tests/SessionProviderTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ray\AuraSessionModule;
+
+use Aura\Session\Session;
+use PHPUnit\Framework\TestCase;
+
+class SessionProviderTest extends TestCase
+{
+    public function testGet(): void
+    {
+        $provider = new SessionProvider();
+        $session = $provider->get();
+        $this->assertInstanceOf(Session::class, $session);
+    }
+}


### PR DESCRIPTION
## Summary

Add Psalm taint annotations to mark session and cookie data as taint sources.

## Changes

- `@psalm-taint-source input` on:
  - `SessionProvider::get()` - returns Session initialized with `$_COOKIE`
  - `CookieProvider::get()` - returns `$_COOKIE` directly

Also includes code style fixes (phpcbf).

## Test Plan

- [ ] Existing tests pass
- [ ] Run `./vendor/bin/psalm --taint-analysis` to verify annotations work

## Summary by Sourcery

Mark session and cookie providers as taint sources for static analysis and apply minor coding style improvements.

Enhancements:
- Annotate session and cookie provider getters with Psalm taint-source metadata for input data.
- Add strict types, return type hints, and PSR-compliant attribute usage and formatting across session-related classes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Cookie-related annotations split into separate attributes (may affect tooling that reads combined attributes).
  * Added strict typing and modernized instantiation/return typing for session handling.
  * Minor docblock standardization and added code analysis/taint annotations.

* **Tests**
  * New unit tests covering session injection, session provider, and cookie deletion behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ray-di/Ray.AuraSessionModule/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->